### PR TITLE
Enhance Podman Role with Webhook Notifications and CI Updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,18 @@ on:
     branches: [main]
 
 jobs:
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .yamllint.yml
+
   ansible-lint:
     name: ansible-lint
     runs-on: ubuntu-latest
@@ -27,3 +39,6 @@ jobs:
 
       - name: Run ansible-lint
         run: ansible-lint
+
+      - name: Syntax check
+        run: ansible-playbook playbooks/nomadintosh.yml -i inventory/hosts.example.yml --syntax-check

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  line-length:
+    max: 160
+    level: warning
+  truthy:
+    allowed-values: ["true", "false", "yes", "no"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing to Nomadintosh!
 1. Fork the repository and clone your fork.
 2. Install dependencies on your control machine:
    ```zsh
-   brew install ansible ansible-lint
+   brew install ansible ansible-lint yamllint
    ansible-galaxy collection install -r collections/requirements.yml
    ```
 3. Copy the example inventory and fill in your hosts:
@@ -20,13 +20,17 @@ Thanks for your interest in contributing to Nomadintosh!
 - **New roles** should follow the existing structure: `defaults/main.yml`, `tasks/main.yml`, and a `README.md` documenting all variables.
 - **Variable names** must be prefixed with the role name (e.g. `consul_`, `nomad_`). This is enforced by `ansible-lint`.
 - **Templates** live in `roles/<role>/templates/`. Jinja2 files use `.j2` extensions.
+- **Reusable task files** that aren't tied to a specific role live in `playbooks/tasks/`. These are included via `ansible.builtin.import_tasks` and run with `delegate_to: localhost` where appropriate (e.g. the webhook notification task).
 
-Before opening a pull request, run the dry-run check and linter:
+Before opening a pull request, run the dry-run check and linters:
 
 ```zsh
 ./check.zsh       # ansible-playbook --check --diff
 ansible-lint      # must pass with 0 failures
+yamllint .        # must pass with 0 errors
 ```
+
+The CI workflow also runs a syntax check (`ansible-playbook --syntax-check`) against the example inventory. If your changes introduce new roles or task files, make sure they are reachable from `playbooks/nomadintosh.yml` and will parse cleanly with the variables defined in `inventory/hosts.example.yml`.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Hosts are organised into named groups; the group name becomes the Consul/Nomad [
 | Variable | Values | Purpose |
 |---|---|---|
 | `server` | `true` / _(absent)_ | Configures the host as a Nomad/Consul server |
+| `container` | `true` / _(absent)_ | Installs Apple's [Container](https://github.com/apple/container) CLI and registers a LaunchAgent |
 | `podman` | `true` / _(absent)_ | Installs and configures the Podman task driver |
 | `docker` | `true` / _(absent)_ | Installs and configures Docker Desktop |
 | `gh_actions` | `true` / _(absent)_ | Deploys a GitHub Actions runner Nomad job |
@@ -81,18 +82,33 @@ For every host, the playbook performs the following steps:
 1. **Facts** — asserts the host is running macOS and sets the `datacenter` fact derived from the host's inventory group name.
 2. **Software Update** — downloads all pending macOS system updates via `softwareupdate`, installs any available Command Line Tools for Xcode, and warns if a restart is required.
 3. **Homebrew** — [Homebrew](https://brew.sh/) is the package manager of choice for this project. The playbook installs Homebrew if not present, taps `hashicorp/tap`, and installs any packages listed in `additional_homebrew_packages`. All system packages — including Consul, Nomad, Podman, and the Apple Container CLI — are managed exclusively through Homebrew.
-4. **Docker Desktop** _(hosts with `docker: true`)_ — installs and configures Docker Desktop.
-5. **Podman** _(hosts with `podman: true`)_ — installs Podman, initialises the machine, and installs the [`nomad-driver-podman`](https://developer.hashicorp.com/nomad/plugins/drivers/podman) plugin.
-6. **Consul** — creates config/data directories, installs Consul via Homebrew, templates [`server.hcl`](https://developer.hashicorp.com/consul/docs/reference/agent/configuration-file) with datacenter, node name, server/client mode, and [`retry_join`](https://developer.hashicorp.com/consul/docs/reference/agent/configuration-file/general#retry_join) derived from inventory, and registers a LaunchAgent.
-7. **Nomad** — creates config/data directories, installs Nomad via Homebrew, templates [`server.hcl`](https://developer.hashicorp.com/nomad/docs/configuration) (including [`bootstrap_expect`](https://developer.hashicorp.com/nomad/docs/configuration/server#bootstrap_expect) and [`retry_join`](https://developer.hashicorp.com/nomad/docs/configuration/server_join)), and registers a LaunchAgent.
-8. **Nomad Jobs** — each optional job follows the same two-step process: the playbook renders a Jinja2 HCL template into a `.nomad.hcl` file under `{{ nomad_jobs_dir }}` (`/opt/nomad/jobs`), then submits it to the local Nomad agent via `nomad job run`. Jobs run as long-lived `service`-type allocations using the `raw_exec` driver, executing native binaries directly on the host. See [JOBS.md](JOBS.md) for a full reference of every supported job, including resource allocations, ports, and configuration variables.
+4. **Apple Container** _(hosts with `container: true`)_ — installs Apple's [Container](https://github.com/apple/container) CLI via Homebrew and registers a LaunchAgent that starts the container system at login. On the Nomad side, the playbook downloads and installs [`nomad-driver-container`](https://github.com/anultravioletaurora/nomad-driver-container) — a custom Nomad task driver that integrates Nomad's scheduling with Apple's Container runtime. This allows Nomad jobs to run OCI containers natively on macOS using Apple's Virtualization.framework, without Docker Desktop or a Podman VM. The driver is configured in `nomad.d/server.hcl` with garbage collection enabled and log collection active.
+5. **Docker Desktop** _(hosts with `docker: true`)_ — installs and configures Docker Desktop.
+6. **Podman** _(hosts with `podman: true`)_ — installs Podman, initialises the machine, and installs the [`nomad-driver-podman`](https://developer.hashicorp.com/nomad/plugins/drivers/podman) plugin.
+7. **Consul** — creates config/data directories, installs Consul via Homebrew, templates [`server.hcl`](https://developer.hashicorp.com/consul/docs/reference/agent/configuration-file) with datacenter, node name, server/client mode, and [`retry_join`](https://developer.hashicorp.com/consul/docs/reference/agent/configuration-file/general#retry_join) derived from inventory, and registers a LaunchAgent.
+8. **Nomad** — creates config/data directories, installs Nomad via Homebrew, templates [`server.hcl`](https://developer.hashicorp.com/nomad/docs/configuration) (including [`bootstrap_expect`](https://developer.hashicorp.com/nomad/docs/configuration/server#bootstrap_expect) and [`retry_join`](https://developer.hashicorp.com/nomad/docs/configuration/server_join)), configures any enabled task driver plugins (`nomad-driver-container`, `nomad-driver-podman`), and registers a LaunchAgent.
+9. **Nomad Jobs** — each optional job follows the same two-step process: the playbook renders a Jinja2 HCL template into a `.nomad.hcl` file under `{{ nomad_jobs_dir }}` (`/opt/nomad/jobs`), then submits it to the local Nomad agent via `nomad job run`. Jobs run as long-lived `service`-type allocations using the `raw_exec` driver, executing native binaries directly on the host. See [JOBS.md](JOBS.md) for a full reference of every supported job, including resource allocations, ports, and configuration variables.
 
-Services are managed as macOS LaunchAgents (Nomad, Consul, and optionally the Podman machine).
+Services are managed as macOS LaunchAgents (Nomad, Consul, and optionally the Podman machine and Apple Container system).
+
+## Notifications
+
+A reusable webhook task file is available at [`playbooks/tasks/notify.yml`](playbooks/tasks/notify.yml). Import it anywhere in a playbook to POST a notification on completion:
+
+```yaml
+- name: Send completion notification
+  ansible.builtin.import_tasks: tasks/notify.yml
+  vars:
+    webhook_message: "nomadintosh deployment completed"
+```
+
+Store `notify_webhook_url` in Ansible Vault. The default body format is Discord-compatible (`content` + `username`); override with `webhook_body` for other platforms.
 
 ## Remarks
 
 - **Platform** — This playbook is tested against Apple Silicon running macOS 26 Tahoe. Mileage on x86 Macs or other macOS versions may vary.
 - **Bare-metal preference** — Where possible, workloads are deployed as native bare-metal jobs rather than containers. This is a deliberate choice to optimise performance on macOS — specifically to avoid the memory overhead of the Linux VM that Docker Desktop and Podman require on macOS, and to take advantage of native hardware acceleration (Metal, VideoToolbox, Core ML) which is unavailable or requires passthrough configuration inside a container runtime.
+- **`nomad-driver-container` is experimental** — The [nomad-driver-container](https://github.com/anultravioletaurora/nomad-driver-container) plugin is an early-stage, lightly tested project. It may behave unexpectedly, and is not recommended for workloads where stability is critical.
 
 ## Special Thanks
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 roles_path = roles
+inventory = inventory/hosts.yml

--- a/check.zsh
+++ b/check.zsh
@@ -1,4 +1,4 @@
 #! /bin/zsh
 
 # Run Nomadintosh in check mode
-ansible-playbook -i inventory/hosts.yml playbooks/nomadintosh.yml --check --diff
+ansible-playbook playbooks/nomadintosh.yml --check --diff

--- a/deploy.zsh
+++ b/deploy.zsh
@@ -1,4 +1,4 @@
 #! /bin/zsh
 
 # Deploy Nomad and Consul
-ansible-playbook -i inventory/hosts.yml playbooks/nomadintosh.yml
+ansible-playbook playbooks/nomadintosh.yml

--- a/playbooks/tasks/notify.yml
+++ b/playbooks/tasks/notify.yml
@@ -27,4 +27,6 @@
   loop: "{{ notifications | default([]) }}"
   loop_control:
     loop_var: notification
-  when: notification.type == 'discord'
+  when:
+    - not ansible_check_mode
+    - notification.type == 'discord'

--- a/playbooks/tasks/notify.yml
+++ b/playbooks/tasks/notify.yml
@@ -1,0 +1,30 @@
+# Reusable webhook notification task file.
+#
+# Include anywhere in a playbook with import_tasks or include_tasks:
+#
+#   - name: Send completion notification
+#     ansible.builtin.import_tasks: tasks/notify.yml
+#     vars:
+#       webhook_message: "nomadintosh deployment completed"
+#
+# Required variables:
+#   notifications — a list of notification configurations (store in Ansible Vault)
+#   webhook_message  — the message string to send
+#
+# Optional variables:
+#   webhook_username — display name shown in the notification (default: "Ansible")
+#   webhook_body     — override the entire POST body dict (default: Slack/Discord-compatible)
+
+- name: POST webhook notification
+  ansible.builtin.uri:
+    url: "{{ notification.url }}"
+    method: POST
+    body_format: json
+    body: "{{ webhook_body | default({'content': webhook_message, 'username': webhook_username | default('Ansible')}) }}"
+    status_code: [200, 204]
+  no_log: true
+  delegate_to: localhost
+  loop: "{{ notifications | default([]) }}"
+  loop_control:
+    loop_var: notification
+  when: notification.type == 'discord'

--- a/roles/nomad/tasks/container_driver.yml
+++ b/roles/nomad/tasks/container_driver.yml
@@ -11,12 +11,22 @@
     owner: "{{ ansible_user }}"
     group: "staff"
 
-- name: Unarchive Container driver plugin
-  ansible.builtin.unarchive:
-    src: "https://github.com/anultravioletaurora/nomad-driver-container/releases/download/v{{ nomad_container_driver_version }}/nomad-driver-container-darwin-arm64.tar.gz"
-    dest: "/tmp/{{ nomad_container_driver_name }}"
-    remote_src: yes
-    
+- name: Download Container driver plugin
+  ansible.builtin.get_url:
+    url: "https://github.com/anultravioletaurora/nomad-driver-container/releases/download/v{{ nomad_container_driver_version }}/nomad-driver-container-darwin-arm64.tar.gz"
+    dest: "/tmp/{{ nomad_container_driver_name }}/nomad-driver-container-darwin-arm64.tar.gz"
+    mode: '0644'
+
+- name: Extract Container driver plugin
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/tar
+      - xzf
+      - "/tmp/{{ nomad_container_driver_name }}/nomad-driver-container-darwin-arm64.tar.gz"
+      - -C
+      - "/tmp/{{ nomad_container_driver_name }}"
+    creates: "/tmp/{{ nomad_container_driver_name }}/nomad-driver-container"
+
 
 - name: Move Container driver plugin to Nomad plugins directory
   ansible.builtin.copy:

--- a/roles/nomad/tasks/install.yml
+++ b/roles/nomad/tasks/install.yml
@@ -9,3 +9,13 @@
 - name: Register if Nomad was installed or updated
   ansible.builtin.set_fact:
     nomad_package_updated: "{{ nomad_package_install.changed }}"
+
+- name: Notify if Nomad was installed or updated
+  ansible.builtin.debug:
+    msg: "Nomad was {{ 'installed' if nomad_package_install.changed else 'already up to date' }}."
+
+- name: Send Webhook notification if Nomad was installed or updated
+  ansible.builtin.import_tasks: tasks/notify.yml
+  vars:
+    webhook_message: "Nomad was {{ 'installed' if nomad_package_install.changed else 'already up to date' }} on node {{ inventory_hostname }}."
+  when: nomad_package_install.changed

--- a/roles/podman/defaults/main.yml
+++ b/roles/podman/defaults/main.yml
@@ -1,0 +1,1 @@
+podman_machine_name: "podman-machine-default"

--- a/roles/podman/tasks/init-machine.yml
+++ b/roles/podman/tasks/init-machine.yml
@@ -4,8 +4,9 @@
       - "{{ homebrew_dir }}/bin/podman"
       - machine
       - init
+      - "{{ podman_machine_name }}"
   args:
-    creates: /Users/{{ ansible_user }}/.config/containers/podman/machine/applehv/podman-machine-default.ign
+    creates: /Users/{{ ansible_user }}/.config/containers/podman/machine/applehv/{{ podman_machine_name }}.ign
 
 - name: Start Podman Machine
   ansible.builtin.command:
@@ -13,5 +14,22 @@
       - "{{ homebrew_dir }}/bin/podman"
       - machine
       - start
-  register: podman_machine_start
-  changed_when: "'Started' in podman_machine_start.stdout"
+      - "{{ podman_machine_name }}"
+  async: 120
+  poll: 0
+  changed_when: true
+
+- name: Wait for Podman Machine to be running
+  ansible.builtin.command:
+    argv:
+      - "{{ homebrew_dir }}/bin/podman"
+      - machine
+      - inspect
+      - --format
+      - "{{ '{{.State}}' }}"
+      - "{{ podman_machine_name }}"
+  register: podman_machine_state
+  until: podman_machine_state.stdout | trim == "running"
+  retries: 24
+  delay: 5
+  changed_when: false

--- a/roles/podman/tasks/launchagent.yml
+++ b/roles/podman/tasks/launchagent.yml
@@ -1,15 +1,27 @@
 - name: Apply Launch Agent for Podman
   ansible.builtin.template:
-    src: templates/LaunchAgents/com.podman.machine.default.plist.j2
+    src: LaunchAgents/com.podman.machine.default.plist.j2
     dest: "/Users/{{ ansible_user }}/Library/LaunchAgents/com.podman.machine.default.plist"
     mode: '0644'
     owner: "{{ ansible_user }}"
     group: staff
 
+- name: Check if Podman Launch Agent is already loaded
+  ansible.builtin.command:
+    argv:
+      - launchctl
+      - list
+      - com.podman.machine.default
+  register: podman_launchctl
+  failed_when: false
+  changed_when: false
+
 - name: Load Podman Launch Agent
+  when: podman_launchctl.rc != 0
   ansible.builtin.command:
     argv:
       - launchctl
       - bootstrap
       - gui/{{ ansible_user_uid }}
       - /Users/{{ ansible_user }}/Library/LaunchAgents/com.podman.machine.default.plist
+  changed_when: true

--- a/roles/software_update/tasks/main.yml
+++ b/roles/software_update/tasks/main.yml
@@ -21,6 +21,12 @@
         msg: "[software_update] Restart required for node {{ inventory_hostname }}"
       when: "'restart' in software_update_restart_required.stdout | lower"
 
+    - name: Invoke Notify playbook if restart is required
+      ansible.builtin.import_tasks: tasks/notify.yml
+      vars:
+        webhook_message: "Restart required for node {{ inventory_hostname }} after software updates."
+      when: "'restart' in software_update_restart_required.stdout | lower"
+
 - name: Install Command Line Tools for Xcode
   become: true
   ansible.builtin.shell: |


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Nomadintosh project, focusing on enhanced automation, notification capabilities, container support, and documentation. The most significant changes include adding a reusable webhook notification task, improved CI linting and syntax checks, support for Apple's Container CLI and the experimental `nomad-driver-container`, and enhancements to Podman configuration and startup reliability.

**Automation and Notification Enhancements:**

* Added a reusable webhook notification task file at `playbooks/tasks/notify.yml`, which can be imported in any playbook to send notifications (e.g., to Discord) on completion or specific events. This is now used after Nomad installation/updates and when a restart is required after software updates (`playbooks/tasks/notify.yml`, `roles/nomad/tasks/install.yml`, `roles/software_update/tasks/main.yml`). [[1]](diffhunk://#diff-10dafcd5a302502e22272388c82b50e6f9e1170f96c0bbca031a7e9be00af239R1-R32) [[2]](diffhunk://#diff-a033f28d2319df0052466c7fb9e88e384af356cfbd968b07120245a6c667d007R12-R21) [[3]](diffhunk://#diff-5b8049d72cd6efa2937ad3922a1e16513bc72ff5ab3b12e37511568f34fab7eeR24-R29)
* Updated documentation in `CONTRIBUTING.md` and `README.md` to explain the new notification mechanism and requirements for running linters before PRs. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R23-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R111)

**CI/CD and Linting Improvements:**

* Integrated `yamllint` into the GitHub Actions workflow, added a `.yamllint.yml` config, and updated `CONTRIBUTING.md` to require passing YAML lint checks. Also added a syntax check step for Ansible playbooks in CI. [[1]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R10-R21) [[2]](diffhunk://#diff-30b790babe62563b34027e5e7719d7528664b0465d715c33bfc4a1d9144f0b8dR1-R8) [[3]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R42-R44) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L10-R10)
* Set the default inventory in `ansible.cfg` and updated scripts (`check.zsh`, `deploy.zsh`) to remove redundant inventory arguments. [[1]](diffhunk://#diff-13210d77ac2772aae5c065289c79fa9fbe18245da49ce14d4db717ca599fdd1bR3) [[2]](diffhunk://#diff-fdb6c6a6f7211f95be8a216edf19d08a1e8264549c269e91fe79e005fa6224e4L4-R4) [[3]](diffhunk://#diff-26f7736e1c14688a4e79bd5e99f6a73a3aebd1cd436188dd08868f3dc87b7b96L4-R4)

**Apple Container and Nomad Driver Support:**

* Added support for installing Apple's [Container CLI](https://github.com/apple/container) and the experimental [`nomad-driver-container`](https://github.com/anultravioletaurora/nomad-driver-container`), allowing native OCI container workloads on macOS without Docker or Podman. Updated `README.md` to document this and warn about the experimental status. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R111)
* Improved the installation workflow for the Container driver plugin to use `get_url` and explicit extraction, increasing reliability.

**Podman Improvements:**

* Made the Podman machine name configurable via `podman_machine_name` in defaults, and updated the initialization and launch agent tasks to use this variable. Improved startup reliability by waiting for the Podman machine to reach the "running" state and ensuring the LaunchAgent is only loaded if not already active. [[1]](diffhunk://#diff-80bb09d9497c03664288950edb27145ea2e37a532dc518ed88f15a2e3fdf41abR1) [[2]](diffhunk://#diff-9403c182af84d1efdf9b44a52acc240426f4941bdb81a53f6d11f2486a28ce8dR7-R35) [[3]](diffhunk://#diff-4d9b1d4618194e7b920a5a98fb232133cdf7f1c8be11d95ee74997420f25eb33L3-R27)

**Documentation Updates:**

* Expanded documentation in `README.md` and `CONTRIBUTING.md` to clarify the structure for reusable tasks, notification setup, and the order and details of playbook steps, including the new Apple Container and notification features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R111) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R23-R34)

These changes collectively enhance the project's automation, reliability, and extensibility, while improving contributor guidance and system observability.