### PR TITLE
Update Service Enablement Structure, Fixes to Apple Container + Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,29 @@ Hosts are organised into named groups; the group name becomes the Consul/Nomad [
 
 | Variable | Values | Purpose |
 |---|---|---|
-| `server` | `true` / _(absent)_ | Configures the host as a Nomad/Consul server |
-| `container` | `true` / _(absent)_ | Installs Apple's [Container](https://github.com/apple/container) CLI and registers a LaunchAgent |
-| `podman` | `true` / _(absent)_ | Installs and configures the Podman task driver |
-| `docker` | `true` / _(absent)_ | Installs and configures Docker Desktop |
-| `gh_actions` | `true` / _(absent)_ | Deploys a GitHub Actions runner Nomad job |
-| `minecraft` | `true` / _(absent)_ | Deploys a Minecraft server Nomad job |
+| `server.enabled` | `true` / _(absent)_ | Configures the host as a Nomad/Consul server |
+| `container.enabled` | `true` / _(absent)_ | Installs Apple's [Container](https://github.com/apple/container) CLI and registers a LaunchAgent |
+| `podman.enabled` | `true` / _(absent)_ | Installs and configures the Podman task driver |
+| `docker.enabled` | `true` / _(absent)_ | Installs and configures Docker Desktop |
+| `gh_actions.enabled` | `true` / _(absent)_ | Deploys a GitHub Actions runner Nomad job |
+| `minecraft.enabled` | `true` / _(absent)_ | Deploys a Minecraft server Nomad job |
 | `volumes` | list of `{name, path}` | Configures [Nomad host volumes](https://developer.hashicorp.com/nomad/docs/configuration/client#host_volume) on the client |
+
+Example host definition:
+
+```yaml
+galileo.jellify.app:
+  server:
+    enabled: true
+  container:
+    enabled: true
+  podman:
+    enabled: true
+  gh_actions:
+    enabled: true
+  minecraft:
+    enabled: true
+```
 
 ## Running the playbook
 

--- a/playbooks/nomadintosh.yml
+++ b/playbooks/nomadintosh.yml
@@ -27,17 +27,17 @@
     - name: Include Container role
       ansible.builtin.include_role:
         name: container
-      when: container | default(false)
+      when: container.enabled | default(false)
 
     - name: Include Docker Desktop role
       ansible.builtin.include_role:
         name: docker_desktop
-      when: docker | default(false)
+      when: docker.enabled | default(false)
 
     - name: Include Podman role
       ansible.builtin.include_role:
         name: podman
-      when: podman | default(false)
+      when: podman.enabled | default(false)
 
     - name: Include Consul role
       ansible.builtin.include_role:
@@ -53,14 +53,14 @@
         - name: Include GH Actions Role
           ansible.builtin.include_role:
             name: github_actions
-          when: gh_actions | default(false)
+          when: gh_actions.enabled | default(false)
 
         - name: Include Minecraft Server Role
           ansible.builtin.include_role:
             name: minecraft
-          when: minecraft | default(false)
+          when: minecraft.enabled | default(false)
 
         - name: Include Zitadel Role
           ansible.builtin.include_role:
             name: zitadel
-          when: zitadel | default(false)
+          when: zitadel.enabled | default(false)

--- a/roles/consul/templates/consul.d/server.hcl.j2
+++ b/roles/consul/templates/consul.d/server.hcl.j2
@@ -1,7 +1,7 @@
 {# Resolve the datacenter name and server node list from inventory #}
 {% set ns = namespace(dc=none, servers=[]) %}
 {% for host in groups['all'] %}
-{%   if hostvars[host]['server'] | default(false) %}
+{%   if 'server' in hostvars[host] and hostvars[host]['server'] is mapping and hostvars[host]['server']['enabled'] | default(false) %}
 {%     set ns.servers = ns.servers + [host] %}
 {%     if ns.dc is none %}
 {%       set ns.dc = hostvars[host]['group_names'] | reject('equalto', 'all') | reject('equalto', 'ungrouped') | first %}
@@ -12,11 +12,11 @@ datacenter = "{{ ns.dc }}"
 node_name  = "{{ inventory_hostname_short }}"
 data_dir   = "{{ consul_working_dir }}"
 
-server = {{ server | default(false) | lower }}
-{% if server | default(false) %}
+server = {{ server.enabled | default(false) | lower }}
+{% if server.enabled | default(false) %}
 bootstrap_expect = {{ ns.servers | length }}
 {% endif %}
-ui = {{ server | default(false) | lower }}
+ui = {{ server.enabled | default(false) | lower }}
 
 bind_addr      = "0.0.0.0"
 client_addr    = "0.0.0.0"

--- a/roles/container/tasks/launch_agent.yml
+++ b/roles/container/tasks/launch_agent.yml
@@ -1,3 +1,4 @@
+---
 - name: Apply Launch Agent for Apple Container
   ansible.builtin.template:
     src: com.apple.container.plist.j2

--- a/roles/container/tasks/main.yml
+++ b/roles/container/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # https://formulae.brew.sh/formula/container#default
 - name: Install Apple Container via Homebrew
   community.general.homebrew:

--- a/roles/nomad/defaults/main.yml
+++ b/roles/nomad/defaults/main.yml
@@ -4,5 +4,5 @@ nomad_plugin_dir: "{{ nomad_working_dir }}/plugins"
 nomad_podman_driver_version: "0.6.4"
 nomad_podman_driver_name: "nomad-driver-podman"
 
-nomad_container_driver_version: "0.1.1-dev-7ba1610"
+nomad_container_driver_version: "0.1.1-dev-827d5f8"
 nomad_container_driver_name: "nomad-driver-container"

--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -7,11 +7,11 @@
 
 - name: Download Container driver plugin
   ansible.builtin.import_tasks: container_driver.yml
-  when: container | default(false)
+  when: container.enabled | default(false)
 
 - name: Download Podman driver plugin
   ansible.builtin.import_tasks: podman_driver.yml
-  when: podman | default(false)
+  when: podman.enabled | default(false)
 
 - name: Apply Nomad configuration templates
   become: true

--- a/roles/nomad/templates/nomad.d/server.hcl.j2
+++ b/roles/nomad/templates/nomad.d/server.hcl.j2
@@ -3,7 +3,7 @@
 {# Collect all Nomad server hostnames from inventory #}
 {% set ns = namespace(servers=[]) %}
 {% for host in groups['all'] %}
-{%   if hostvars[host]['server'] | default(false) %}
+{%   if 'server' in hostvars[host] and hostvars[host]['server'] is mapping and hostvars[host]['server']['enabled'] | default(false) %}
 {%     set ns.servers = ns.servers + [host] %}
 {%   endif %}
 {% endfor %}
@@ -17,8 +17,8 @@ retry_join = ["{{ ns.servers | join('", "') }}"]
 
 # Control plane on this box
 server {
-  enabled = {{ server | default(false) | lower }}
-{% if server | default(false) %}
+  enabled = {{ server.enabled | default(false) | lower }}
+{% if server.enabled | default(false) %}
   bootstrap_expect = {{ ns.servers | length }}
 {% endif %}
 }
@@ -45,7 +45,7 @@ plugin "raw_exec" {
   config { enabled = true } 
 }
 
-{% if container | default(false) %}
+{% if container.enabled | default(false) %}
 plugin "nomad-driver-container" {
   config {
     container_path = "/opt/homebrew/bin/container"
@@ -60,7 +60,7 @@ plugin "nomad-driver-container" {
 {% endif %}
 
 
-{% if podman | default(false) %}
+{% if podman.enabled | default(false) %}
 plugin "nomad-driver-podman" {
   config {
     socket_path = "{{ podman_socket_path }}"
@@ -68,7 +68,7 @@ plugin "nomad-driver-podman" {
 }
 {% endif %}
 
-{% if docker | default(false) %}
+{% if docker.enabled | default(false) %}
 plugin "docker" {
   config {
     endpoint = "unix:///var/run/docker.sock"


### PR DESCRIPTION
update container plugin
This pull request updates the way host features are enabled and referenced throughout the project, moving from simple boolean flags to a nested dictionary structure (e.g., `container.enabled` instead of `container`). This change is reflected in documentation, Ansible playbooks, templates, and role task files to improve clarity and extensibility. Additionally, the container driver version is updated.

Key changes include:

**Variable Structure Refactor:**

* Updated all feature flags in the documentation, Ansible playbooks (`nomadintosh.yml`), and Jinja2 templates to use the `.enabled` property (e.g., `container.enabled`, `podman.enabled`, etc.) instead of a plain boolean (e.g., `container`). This affects conditional checks throughout the codebase. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R67) [[2]](diffhunk://#diff-fa292e84066106f2f7120e2d62101cc1da2d0b8afcee3d9e653cc122c7dea204L30-R40) [[3]](diffhunk://#diff-fa292e84066106f2f7120e2d62101cc1da2d0b8afcee3d9e653cc122c7dea204L56-R66) [[4]](diffhunk://#diff-8a375fff1b9a6ce02854935b0dd97e62806cfbdd90c947aaa1cf6d09b451200fL4-R4) [[5]](diffhunk://#diff-8a375fff1b9a6ce02854935b0dd97e62806cfbdd90c947aaa1cf6d09b451200fL15-R19) [[6]](diffhunk://#diff-095386378e6bb8152e0a69f95bb92c9817053b89b5b50b6ed0dfbfc1aa0d6d97L10-R14) [[7]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL6-R6) [[8]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL20-R21) [[9]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL48-R48) [[10]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL63-R71)

* Added a YAML example in the documentation to illustrate the new nested structure for enabling features on hosts.

**Template and Role Updates:**

* Updated Jinja2 templates for Consul and Nomad configuration to use the new nested variable structure and ensure correct server/feature detection. [[1]](diffhunk://#diff-8a375fff1b9a6ce02854935b0dd97e62806cfbdd90c947aaa1cf6d09b451200fL4-R4) [[2]](diffhunk://#diff-8a375fff1b9a6ce02854935b0dd97e62806cfbdd90c947aaa1cf6d09b451200fL15-R19) [[3]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL6-R6) [[4]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL20-R21) [[5]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL48-R48) [[6]](diffhunk://#diff-e5ca7c2c0c59a2130425d343331d7ca763fd5e9a79cd999a7dccbd6b15af346fL63-R71)

* Updated Ansible role tasks to reference the new `.enabled` property when including roles or importing tasks. [[1]](diffhunk://#diff-fa292e84066106f2f7120e2d62101cc1da2d0b8afcee3d9e653cc122c7dea204L30-R40) [[2]](diffhunk://#diff-fa292e84066106f2f7120e2d62101cc1da2d0b8afcee3d9e653cc122c7dea204L56-R66) [[3]](diffhunk://#diff-095386378e6bb8152e0a69f95bb92c9817053b89b5b50b6ed0dfbfc1aa0d6d97L10-R14)

**Version and Formatting Updates:**

* Bumped the `nomad_container_driver_version` to `0.1.1-dev-827d5f8` in the Nomad role defaults.

* Added YAML document start markers (`---`) to `roles/container/tasks/main.yml` and `roles/container/tasks/launch_agent.yml` for consistency. [[1]](diffhunk://#diff-4a2cbf5e775eb147477ed806ab0a51343aeb0b0eb391afb7dd0bf9b447ab8e29R1) [[2]](diffhunk://#diff-df2ca93dd3ce75236690cbe5f78e49f1212c67c7a723efebc5b9d2c1fb050992R1)