### PR TITLE
feat: Add GitHub ENV var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Hosts are organised into named groups; the group name becomes the Consul/Nomad [
 | `podman.enabled` | `true` / _(absent)_ | Installs and configures the Podman task driver |
 | `docker.enabled` | `true` / _(absent)_ | Installs and configures Docker Desktop |
 | `gh_actions.enabled` | `true` / _(absent)_ | Deploys a GitHub Actions runner Nomad job |
+| `gh_actions.env` | map / _(absent)_ | Environment variables injected into the runner process |
 | `minecraft.enabled` | `true` / _(absent)_ | Deploys a Minecraft server Nomad job |
 | `volumes` | list of `{name, path}` | Configures [Nomad host volumes](https://developer.hashicorp.com/nomad/docs/configuration/client#host_volume) on the client |
 

--- a/inventory/README.md
+++ b/inventory/README.md
@@ -60,9 +60,24 @@ Variables defined directly under a hostname override any group-level `vars` for 
 | `podman.enabled` | `false` | Installs Podman and the [nomad-driver-podman](https://developer.hashicorp.com/nomad/plugins/drivers/podman) plugin |
 | `docker.enabled` | `false` | Installs Docker Desktop and enables the Nomad Docker driver |
 | `gh_actions.enabled` | `false` | Deploys a GitHub Actions self-hosted runner as a Nomad job |
+| `gh_actions.env` | _(absent)_ | Map of environment variables injected into the runner process (see below) |
 | `minecraft.enabled` | `false` | Deploys a Minecraft server as a Nomad job |
 | `container.enabled` | `false` | Installs Apple's Container CLI and registers a LaunchAgent |
 | `volumes` | _(absent)_ | List of host volumes to expose to the Nomad client (see below) |
+
+#### `gh_actions.env` format
+
+An optional map of key/value pairs passed as environment variables to the GitHub Actions runner process via the Nomad job's `env {}` block. Useful for variables that would normally be sourced from a login shell (e.g. `/etc/profile`) but are not visible to processes launched by Nomad:
+
+```yaml
+gh_actions:
+  enabled: true
+  env:
+    MY_VAR: "some-value"
+    ANOTHER_VAR: "another-value"
+```
+
+If `gh_actions.env` is absent, no `env {}` block is added to the job.
 
 #### `volumes` format
 

--- a/playbooks/nomadintosh.yml
+++ b/playbooks/nomadintosh.yml
@@ -48,5 +48,5 @@
       ansible.builtin.include_role:
         name: nomad
 
-    - name: Deploy Nomad Jobs
-      ansible.builtin.import_playbook: jobs.yml
+- name: Deploy Nomad Jobs
+  ansible.builtin.import_playbook: jobs.yml

--- a/roles/github_actions/README.md
+++ b/roles/github_actions/README.md
@@ -28,3 +28,17 @@ The GitHub Actions runner must be **downloaded and configured manually on the ho
 | `gh_actions_executable` | `/opt/github-actions/run.sh` | Path to the runner's `run.sh` script on the host |
 | `job_name` | `actions-runner` | Nomad job name |
 | `job_file_dest` | `{{ nomad_jobs_dir }}/actions-runner.nomad.hcl` | Where the rendered job file is written |
+
+### Environment variables
+
+If the runner process needs environment variables (e.g. variables that would normally be sourced from `/etc/profile` but are unavailable to non-login-shell processes), set them via `gh_actions.env` in the host's inventory entry:
+
+```yaml
+gh_actions:
+  enabled: true
+  env:
+    MY_VAR: "some-value"
+    ANOTHER_VAR: "another-value"
+```
+
+Each key/value pair is rendered into the Nomad job's `env {}` block and injected directly into the runner process at runtime. If `gh_actions.env` is absent the block is omitted entirely.

--- a/roles/github_actions/templates/github-actions-runner.nomad.hcl.j2
+++ b/roles/github_actions/templates/github-actions-runner.nomad.hcl.j2
@@ -8,6 +8,14 @@ job "{{ github_actions_job_name }}" {
     task "actions-runner" {
       driver = "raw_exec"
 
+      {% if gh_actions.env is defined %}
+      env {
+        {% for key, value in gh_actions.env.items() %}
+        {{ key }} = "{{ value }}"
+        {% endfor %}
+      }
+      {% endif %}
+
       config {
         command = "{{ github_actions_executable }}"
       }


### PR DESCRIPTION
This pull request adds support for injecting environment variables into the GitHub Actions runner Nomad job using a new `gh_actions.env` configuration option. This allows users to specify environment variables that are passed directly to the runner process, which is particularly useful for variables that would otherwise be sourced from a login shell but are not available to processes launched by Nomad. The documentation has been updated to explain the new feature and provide usage examples.

**GitHub Actions runner environment variable support:**

* Added support for an optional `gh_actions.env` map that allows users to inject environment variables into the GitHub Actions runner process via the Nomad job's `env {}` block. If the map is absent, no `env {}` block is rendered. (`roles/github_actions/templates/github-actions-runner.nomad.hcl.j2`, [roles/github_actions/templates/github-actions-runner.nomad.hcl.j2R11-R18](diffhunk://#diff-f283bca639241e2ffb64d46c8cef831a014d28e22a60eed071fd3b30b404fccbR11-R18))
* Updated documentation in `README.md`, `inventory/README.md`, and `roles/github_actions/README.md` to describe the new `gh_actions.env` option, its format, and provide usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49) [[2]](diffhunk://#diff-b04140500f3b2aeb73c832c810fdfe4c9bb5187dde52a9d92bee477bd3261076R63-R81) [[3]](diffhunk://#diff-f60723700bc41abb68b3f3bb99dd7ccecc7f32d4716a519d7c7af917eb92ce2fR31-R44)