### PR TITLE
fix: Container not Started After Upgrade

### DIFF
--- a/roles/container/tasks/launch_agent.yml
+++ b/roles/container/tasks/launch_agent.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check if Launch Agent already exists for Apple Container
+  ansible.builtin.stat:
+    path: "/Users/{{ ansible_user }}/Library/LaunchAgents/com.apple.container.plist"
+  register: container_launch_agent_stat
+
 - name: Apply Launch Agent for Apple Container
   ansible.builtin.template:
     src: com.apple.container.plist.j2
@@ -7,10 +12,20 @@
     owner: "{{ ansible_user }}"
     group: staff
 
-- name: Load Apple Container Launch Agent
+- name: Restart Apple Container Launch Agent (already installed, may have been upgraded)
+  ansible.builtin.command:
+    argv:
+      - launchctl
+      - kickstart
+      - -k
+      - gui/{{ ansible_user_uid }}/com.apple.container
+  when: container_launch_agent_stat.stat.exists
+
+- name: Load Apple Container Launch Agent (first install)
   ansible.builtin.command:
     argv:
       - launchctl
       - bootstrap
       - gui/{{ ansible_user_uid }}
       - /Users/{{ ansible_user }}/Library/LaunchAgents/com.apple.container.plist
+  when: not container_launch_agent_stat.stat.exists


### PR DESCRIPTION
This pull request improves the idempotency and reliability of the Apple Container Launch Agent setup in the Ansible playbook. The main changes ensure the Launch Agent is only loaded or restarted when necessary, depending on whether it already exists.

**Launch Agent management improvements:**

* Added a task to check if the Launch Agent plist file exists before attempting to load or restart it, using the `ansible.builtin.stat` module.
* Split the launch process into two separate tasks:
  * If the Launch Agent already exists, use `launchctl kickstart` to restart it, ensuring any upgrades are applied.
  * If the Launch Agent does not exist, use `launchctl bootstrap` to load it for the first time.